### PR TITLE
Avoid duplicating values from other serialized fields

### DIFF
--- a/gravity-post.php
+++ b/gravity-post.php
@@ -82,6 +82,7 @@ class GravityHTTPRequest {
 
 				} elseif ($field['http_output'] === 'serialize') {
 
+                    $serialize = [];
 
 					foreach ($field['inputs'] as $input) {
 


### PR DESCRIPTION
If more than one field is serialized, the array of serialized values wasn't reset, so field N+1 would also carry the values for field N.  Fix just clears the values array each time through the loop.
